### PR TITLE
Panfeed second pass should not do compression

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1021,8 +1021,8 @@ rule panfeed_downstream:
     fastadir2=config["references_fastas"],
     clusters="out/associations/{target}/panfeed_clusters.txt",
     targets="out/associations/{target}/panfeed_targets.txt",
-    k2h="out/associations/{target}/panfeed_second_pass/kmers_to_hashes.tsv.gz",
-    k="out/associations/{target}/panfeed_second_pass/kmers.tsv.gz",
+    k2h="out/associations/{target}/panfeed_second_pass/kmers_to_hashes.tsv",
+    k="out/associations/{target}/panfeed_second_pass/kmers.tsv",
   threads: 4
   conda: "envs/panfeed.yaml"
   log: "out/logs/panfeed_second_pass_{target}.log"
@@ -1048,7 +1048,7 @@ rule panfeed_downstream:
         -p {params.input} \
         --upstream 250 --downstream 100 \
         --no-filter \
-        -v --compress \
+        -v \
         --genes {params.clusters} \
         --targets {params.targets} \
         --cores {threads} 2>> {log} && \
@@ -1058,6 +1058,7 @@ rule panfeed_downstream:
         -a {input.panfeed} \
         -p {params.k2h} \
         -k {params.k} 2>> {log} \
-        | gzip > {output}
+        | gzip > {output} && \
+    rm -rf {params.outdir}
     """
 


### PR DESCRIPTION
For some reason adding `--compress` to the second pass of panfeed results in a crash when using the helper scripts. This change avoids compressing panfeed's output, and we now make sure to delete them once the second pass is finished.