### PR TITLE
fix error while loading library libtabixpp.so.0

### DIFF
--- a/workflow/envs/nucmer.yaml
+++ b/workflow/envs/nucmer.yaml
@@ -10,3 +10,4 @@ dependencies:
  - perl-bioperl=1.7.8
  - bcftools>1.10
  - gsl
+ - tabixpp=1.1.0


### PR DESCRIPTION
Got this error while running on the cluster:

```
vcfstreamsort: error while loading shared libraries: libtabixpp.so.0: cannot open shared object file: No such file or directory
vcfuniq: error while loading shared libraries: libtabixpp.so.0: cannot open shared object file: No such file or directory
```

We fixed it for the pseudomonas gwas by adding this library on the nucmer.yaml env.

 - tabixpp=1.1.0