### PR TITLE
Avoid potential conflicts between concurrent runs of map_back

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -637,11 +637,12 @@ rule run_map_back:
   output:
     "out/associations/{target}/mapped.tsv"
   params:
-    "/tmp/{target}_" + username
+    "/tmp/{target}_map_back_" + username
   conda: "envs/pyseer.yaml"
   log: "out/logs/map_back_{target}.log"
   shell:
     """
+    rm -rf {params} || true
     mkdir -p {params}
     echo -e "strain\\tunitig\\tcontig\\tstart\\tend\\tstrand\\tupstream\\tgene\\tdownstream" > {output}
     python workflow/scripts/map_back.py {input.unitigs} {input.fasta} --tmp-prefix {params} --gff {input.gff} --print-details --pangenome {input.pangenome} >> {output} 2>> {log}
@@ -655,11 +656,12 @@ rule run_map_back_all:
   output:
     "out/associations/{target}/mapped_all.tsv"
   params:
-    "/tmp/{target}_" + username
+    "/tmp/{target}_map_back_all_" + username
   conda: "envs/pyseer.yaml"
   log: "out/logs/map_back_all_{target}.log"
   shell:
     """
+    rm -rf {params} || true
     mkdir -p {params}
     echo -e "strain\\tunitig\\tcontig\\tstart\\tend\\tstrand\\tupstream\\tgene\\tdownstream" > {params}/mapped.tsv
     python workflow/scripts/map_back.py {input.unitigs} {input.reffastadir} --tmp-prefix {params} --gff {input.refgffdir} --print-details >> {params}/mapped.tsv 2> {log}
@@ -693,11 +695,12 @@ rule run_map_back_wg:
   output:
     "out/wg/{target}/mapped_{model}.tsv"
   params:
-    "/tmp/{target}_{model}_" + username
+    "/tmp/{target}_{model}_map_back_" + username
   conda: "envs/pyseer.yaml"
   log: "out/logs/map_back_{model}_{target}.log"
   shell:
     """
+    rm -rf {params} || true
     mkdir -p {params}
     echo -e "strain\\tunitig\\tcontig\\tstart\\tend\\tstrand\\tupstream\\tgene\\tdownstream" > {output}
     python workflow/scripts/map_back.py {input.unitigs} {input.fasta} --tmp-prefix {params} --gff {input.gff} --print-details --pangenome {input.pangenome} >> {output} 2>> {log}

--- a/workflow/scripts/mapped_summary.py
+++ b/workflow/scripts/mapped_summary.py
@@ -118,6 +118,10 @@ if __name__ == "__main__":
     # remove duplicated rows (?!)
     m = m.drop_duplicates(keep='first')
     #
+    # remove short unitigs
+    if not options.panfeed:
+        m['length'] = [len(x) for x in m['unitig'].values]
+        m = m[m['length'] >= options.length]
     if options.unique:
         #singletons = m.groupby(['unitig', 'strain'])['start'].count().reset_index().groupby('unitig')['start'].max()
         singletons = m.groupby(['unitig', 'strain'])['start'].count()
@@ -127,10 +131,6 @@ if __name__ == "__main__":
     # remove unitigs that map to multiple genes across strains
     u = m.groupby('unitig')['gene'].nunique()
     m = m[m['unitig'].isin(u[u <= options.maximum_genes].index)]
-    # remove short unitigs
-    if not options.panfeed:
-        m['length'] = [len(x) for x in m['unitig'].values]
-        m = m[m['length'] >= options.length]
     # check empty
     if m.shape[0] == 0:
         sys.exit(0)


### PR DESCRIPTION
also, attempt to reduce the memory load of `mapped_summary.py` by applying the unitigs length filter earlier