### PR TITLE
Integration of alternative ML models for WG analysis

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,12 +40,12 @@ species_amr: "Escherichia"
 # use "out/lineages_mlst.txt" to use mlst
 # or "out/lineages_poppunk.tsv" for poppunk
 # or an existing file for a custom lineages list
-lineages_file: "out/lineages_mlst.txt"
+lineages_file: "data/lineages.txt"
 
 # eggnogdb: Tax ID of eggNOG HMM database to download
 # default: "2" for Bacteria; else can be "taxid"
 # Available tax IDs can be found at http://eggnog5.embl.de/#/app/downloads
-eggnogdb: "2"
+eggnogdb: "1236"
 
 # filters to remove spurious hits
 # defaults are set as 'loose thresholds'
@@ -172,3 +172,28 @@ wg_inputs: "out/wg/inputs"
 ### enrichments
 annotated_reference: "out/annotated_reference.tsv"
 go_obo: "out/go-basic.obo"
+
+# ---------------------------------------------------------
+# GWAS Execution Mode
+# ---------------------------------------------------------
+# Choose between "pyseer" (ENet on the entire variants file) or "bac-nortia" (Machine Learning)
+wg_method: "pyseer"
+
+# ---------------------------------------------------------
+# Bac-Nortia Machine Learning Configuration
+# ---------------------------------------------------------
+bac_nortia:
+  # Model choice: xgboost, catboost, lightgbm, tabnet, tabpfn
+  model: "xgboost"
+  
+  # Optuna hyperparameter tuning
+  tune_hyperparams: true
+  n_optuna_trials: 50
+  
+  # Cross-validation and filtering
+  cv_folds: 5
+  min_af: 0.05
+  correlation_threshold: 0.95
+  
+  # SHAP evaluation handling ("expand" clusters or use "representative")
+  shap_cluster_handling: "expand"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,12 +40,12 @@ species_amr: "Escherichia"
 # use "out/lineages_mlst.txt" to use mlst
 # or "out/lineages_poppunk.tsv" for poppunk
 # or an existing file for a custom lineages list
-lineages_file: "data/lineages.txt"
+lineages_file: "out/lineages_mlst.txt"
 
 # eggnogdb: Tax ID of eggNOG HMM database to download
 # default: "2" for Bacteria; else can be "taxid"
 # Available tax IDs can be found at http://eggnog5.embl.de/#/app/downloads
-eggnogdb: "1236"
+eggnogdb: "2"
 
 # filters to remove spurious hits
 # defaults are set as 'loose thresholds'
@@ -174,10 +174,10 @@ annotated_reference: "out/annotated_reference.tsv"
 go_obo: "out/go-basic.obo"
 
 # ---------------------------------------------------------
-# GWAS Execution Mode
+# Machine learning execution mode
 # ---------------------------------------------------------
 # Choose between "pyseer" (ENet on the entire variants file) or "bac-nortia" (Machine Learning)
-wg_method: "pyseer"
+wg_method: "bac-nortia"
 
 # ---------------------------------------------------------
 # Bac-Nortia Machine Learning Configuration
@@ -197,3 +197,6 @@ bac_nortia:
   
   # SHAP evaluation handling ("expand" clusters or use "representative")
   shap_cluster_handling: "expand"
+  
+  # Uncomment this line and replace "" with the desired value if you want to set a random seed
+  # random_seed: ""

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -6,6 +6,23 @@ import string
 ##### load config #####
 
 configfile: "config/config.yaml"
+PHENOTYPES = config.get("targets", [])
+
+WG_METHOD = config.get("wg_method", "enet")
+
+if WG_METHOD == "bac-nortia":
+    WG_MODELS_LIST = ["bac_nortia"]
+else:
+    WG_MODELS_LIST = ["ridge", "lasso"]
+
+GWAS_PLOT_INPUTS = (
+    expand("out/associations/{target}/annotated_summary.tsv", target=PHENOTYPES) +
+    expand("out/associations/{target}/KEGG.png", target=PHENOTYPES) +
+    expand("out/associations/{target}/manhattan.png", target=PHENOTYPES) +
+    
+    expand("out/wg/{target}/annotated_summary_{model}.tsv", target=PHENOTYPES, model=WG_MODELS_LIST) +
+    expand("out/wg/{target}/KEGG_{model}.png", target=PHENOTYPES, model=WG_MODELS_LIST)
+)
 
 ##### functions #####
 
@@ -26,6 +43,10 @@ if username is None:
 
 ##### rules #####
 
+rule run_all_gwas:
+    input:
+        GWAS_PLOT_INPUTS
+
 rule ggcaller:
   input:
     fasta_list=config["mash_input"]
@@ -35,7 +56,7 @@ rule ggcaller:
     gfa=config["ggcaller_gfa"]
   params:
     outdir=config["ggcaller_dir"]
-  threads: 16
+  threads: 8
   conda: "envs/ggcaller.yaml"
   log: "out/logs/ggcaller.log"
   shell:
@@ -480,10 +501,7 @@ rule pyseer_vcf:
 
 rule wg:
   input:
-    expand('out/wg/{target}/ridge.tsv',
-           target=config["targets"]),
-    expand('out/wg/{target}/lasso.tsv',
-           target=config["targets"]),
+    expand('out/wg/{target}/{model}.tsv', target=config["targets"], model=WG_MODELS_LIST)
 
 rule run_pyseer:
   input:
@@ -716,11 +734,54 @@ rule run_wg:
            > {output.lasso}
     """
 
+rule run_wg_nortia:
+    input:
+        phenotypes = os.path.join(config["association_inputs"], "{target}/phenotypes.tsv"),
+        rtab = config["pangenome"]
+    output:
+        wg_out = "out/wg/{target}/bac_nortia.tsv",
+        predictions = "out/wg/{target}/bac_nortia_predictions.tsv"
+    params:
+        outdir = "out/wg/{target}/bac_nortia_temp",
+        model = config["bac_nortia"]["model"],
+        trials = lambda w: config["bac_nortia"]["n_optuna_trials"] if config["bac_nortia"]["tune_hyperparams"] else 0,
+        cv = config["bac_nortia"]["cv_folds"],
+        min_af = config["bac_nortia"]["min_af"],
+        corr_thresh = config["bac_nortia"]["correlation_threshold"],
+        shap_handling = config["bac_nortia"]["shap_cluster_handling"],
+        seed = config["bac_nortia"].get("random_seed", 42)
+    conda:
+        "envs/bac_nortia.yaml"
+    log:
+        "out/logs/run_wg_nortia_{target}.log"
+    threads: 8
+    shell:
+        """
+        bac-nortia train \\
+            --phenotype {input.phenotypes} \\
+            --phenotype-column {wildcards.target} \\
+            --variant rtab:{input.rtab} \\
+            --model {params.model} \\
+            --n-optuna-trials {params.trials} \\
+            --cv-folds {params.cv} \\
+            --min-af {params.min_af} \\
+            --correlation-threshold {params.corr_thresh} \\
+            --shap-cluster-handling {params.shap_handling} \\
+            --random-seed {params.seed} \\
+            --n-jobs {threads} \\
+            --output-dir {params.outdir}
+
+        python workflow/scripts/shap_to_wg.py \\
+            --shap {params.outdir}/feature_importance_with_clusters.tsv \\
+            --out {output.wg_out}
+
+        awk 'BEGIN{{OFS="\\t"}} NR==1{{print "sample","actual","predicted"}} NR>1{{print $1,$2,$3}}' \\
+            {params.outdir}/predictions_test.tsv > {output.predictions}
+        """
+
 rule wg_metrics:
   input:
-    expand("out/wg/{target}/metrics_{model}.tsv",
-           target=config["targets"],
-           model=["ridge", "lasso"]),
+    expand("out/wg/{target}/metrics_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST)
 
 rule run_wg_metrics:
   input:
@@ -737,13 +798,9 @@ rule run_wg_metrics:
 
 rule map_back:
   input:
-    expand("out/associations/{target}/mapped.tsv",
-           target=config["targets"]),
-    expand("out/associations/{target}/mapped_all.tsv",
-           target=config["targets"]),
-    expand("out/wg/{target}/mapped_{model}.tsv",
-           target=config["targets"],
-           model=['ridge', 'lasso']),
+    expand("out/associations/{target}/mapped.tsv", target=config["targets"]),
+    expand("out/associations/{target}/mapped_all.tsv", target=config["targets"]),
+    expand("out/wg/{target}/mapped_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST)
 
 rule run_map_back:
   input:
@@ -822,18 +879,19 @@ rule run_map_back_wg:
     rm -rf {params} || true
     mkdir -p {params}
     echo -e "strain\\tunitig\\tcontig\\tstart\\tend\\tstrand\\tupstream\\tgene\\tdownstream" > {output} 2> {log}
-    python workflow/scripts/map_back.py {input.unitigs} {input.fasta} --tmp-prefix {params} --gff {input.gff} --print-details --pangenome {input.pangenome} >> {output} 2>> {log}
+
+    if [ "{wildcards.model}" == "bac_nortia" ]; then
+        awk 'BEGIN {{OFS="\\t"}} NR>1 {{print "dummy", $1, "dummy", 0, 0, "+", "dummy", $1, "dummy"}}' {input.unitigs} >> {output}
+    else
+        python workflow/scripts/map_back.py {input.unitigs} {input.fasta} --tmp-prefix {params} --gff {input.gff} --print-details --pangenome {input.pangenome} >> {output} 2>> {log}
+    fi
     """
 
 rule map_summary:
   input:
-    expand("out/associations/{target}/summary.tsv",
-           target=config["targets"]),
-    expand("out/associations/{target}/summary_panfeed.tsv",
-           target=config["targets"]),
-    expand("out/wg/{target}/summary_{model}.tsv",
-           target=config["targets"],
-           model=["ridge", "lasso"]),
+    expand("out/associations/{target}/summary.tsv", target=config["targets"]),
+    expand("out/associations/{target}/summary_panfeed.tsv", target=config["targets"]),
+    expand("out/wg/{target}/summary_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST)
 
 rule map_summary_fig:
   input:
@@ -942,19 +1000,12 @@ rule run_map_summary_fig:
 
 rule annotate_summary:
   input:
-    expand("out/associations/{target}/annotated_summary.tsv",
-           target=config["targets"]),
-    expand("out/associations/{target}/annotated_rare_summary.tsv",
-           target=config["targets"]),
-    expand("out/associations/{target}/annotated_vcf.tsv",
-           target=config["targets"]),
-    expand("out/associations/{target}/annotated_gpa_summary.tsv",
-           target=config["targets"]),
-    expand("out/associations/{target}/annotated_panfeed_summary.tsv",
-           target=config["targets"]),
-    expand("out/wg/{target}/annotated_summary_{model}.tsv",
-           target=config["targets"],
-           model=["ridge", "lasso"]),
+    expand("out/associations/{target}/annotated_summary.tsv", target=config["targets"]),
+    expand("out/associations/{target}/annotated_rare_summary.tsv", target=config["targets"]),
+    expand("out/associations/{target}/annotated_vcf.tsv", target=config["targets"]),
+    expand("out/associations/{target}/annotated_gpa_summary.tsv", target=config["targets"]),
+    expand("out/associations/{target}/annotated_panfeed_summary.tsv", target=config["targets"]),
+    expand("out/wg/{target}/annotated_summary_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST)
 
 rule run_annotate_summary:
   input:
@@ -1194,30 +1245,12 @@ rule download_obo:
 
 rule enrichment:
   input:
-    expand('out/associations/{target}/COG.tsv',
-           target=config["targets"]),
-    expand('out/associations/{target}/GO.tsv',
-           target=config["targets"]),
-    expand('out/associations/{target}/KEGG.tsv',
-           target=config["targets"]),
-    expand('out/associations/{target}/COG_{kind}.tsv',
-           target=config["targets"],
-           kind=['gpa', 'rare', 'panfeed']),
-    expand('out/associations/{target}/GO_{kind}.tsv',
-           target=config["targets"],
-           kind=['gpa', 'rare', 'panfeed']),
-    expand('out/associations/{target}/KEGG_{kind}.tsv',
-           target=config["targets"],
-           kind=['gpa', 'rare', 'panfeed']),
-    expand("out/wg/{target}/COG_{model}.tsv",
-           target=config["targets"],
-           model=["ridge", "lasso"]),
-    expand("out/wg/{target}/GO_{model}.tsv",
-           target=config["targets"],
-           model=["ridge", "lasso"]),
-    expand("out/wg/{target}/KEGG_{model}.tsv",
-           target=config["targets"],
-           model=["ridge", "lasso"]),
+    expand("out/associations/{target}/COG.tsv", target=config["targets"]),
+    expand("out/associations/{target}/GO.tsv", target=config["targets"]),
+    expand("out/associations/{target}/KEGG.tsv", target=config["targets"]),
+    expand("out/wg/{target}/COG_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST),
+    expand("out/wg/{target}/GO_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST),
+    expand("out/wg/{target}/KEGG_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST)
 
 rule run_enrich:
   input:
@@ -1272,39 +1305,12 @@ rule run_enrich_wg:
 
 rule enrichment_plots:
   input:
-    expand("out/associations/{target}/COG.{format}",
-           target=config["targets"],
-           format=['png', 'svg']),
-    expand("out/associations/{target}/GO.{format}",
-           target=config["targets"],
-           format=['png', 'svg']),
-    expand("out/associations/{target}/KEGG.{format}",
-           target=config["targets"],
-           format=['png', 'svg']),
-    expand('out/associations/{target}/COG_{kind}.{format}',
-           target=config["targets"],
-           kind=['gpa', 'rare', 'panfeed'],
-           format=['png', 'svg']),
-    expand('out/associations/{target}/GO_{kind}.{format}',
-           target=config["targets"],
-           kind=['gpa', 'rare', 'panfeed'],
-           format=['png', 'svg']),
-    expand('out/associations/{target}/KEGG_{kind}.{format}',
-           target=config["targets"],
-           kind=['gpa', 'rare', 'panfeed'],
-           format=['png', 'svg']),
-    expand("out/wg/{target}/COG_{model}.{format}",
-           target=config["targets"],
-           model=["ridge", "lasso"],
-           format=['png', 'svg']),
-    expand("out/wg/{target}/GO_{model}.{format}",
-           target=config["targets"],
-           model=["ridge", "lasso"],
-           format=['png', 'svg']),
-    expand("out/wg/{target}/KEGG_{model}.{format}",
-           target=config["targets"],
-           model=["ridge", "lasso"],
-           format=['png', 'svg']),
+    expand("out/associations/{target}/COG.{format}", target=config["targets"], format=['png', 'svg']),
+    expand("out/associations/{target}/GO.{format}", target=config["targets"], format=['png', 'svg']),
+    expand("out/associations/{target}/KEGG.{format}", target=config["targets"], format=['png', 'svg']),
+    expand("out/wg/{target}/COG_{model}.{format}", target=config["targets"], model=WG_MODELS_LIST, format=['png', 'svg']),
+    expand("out/wg/{target}/GO_{model}.{format}", target=config["targets"], model=WG_MODELS_LIST, format=['png', 'svg']),
+    expand("out/wg/{target}/KEGG_{model}.{format}", target=config["targets"], model=WG_MODELS_LIST, format=['png', 'svg'])
 
 rule run_enrichment_plots:
   input:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -43,10 +43,6 @@ if username is None:
 
 ##### rules #####
 
-rule run_all_gwas:
-    input:
-        GWAS_PLOT_INPUTS
-
 rule ggcaller:
   input:
     fasta_list=config["mash_input"]
@@ -749,7 +745,7 @@ rule run_wg_nortia:
         min_af = config["bac_nortia"]["min_af"],
         corr_thresh = config["bac_nortia"]["correlation_threshold"],
         shap_handling = config["bac_nortia"]["shap_cluster_handling"],
-        seed = config["bac_nortia"].get("random_seed", 42)
+        seed_arg = lambda w: f"--random-seed {config['bac_nortia']['random_seed']}" if config["bac_nortia"].get("random_seed") else ""
     conda:
         "envs/bac_nortia.yaml"
     log:
@@ -767,7 +763,7 @@ rule run_wg_nortia:
             --min-af {params.min_af} \\
             --correlation-threshold {params.corr_thresh} \\
             --shap-cluster-handling {params.shap_handling} \\
-            --random-seed {params.seed} \\
+            {params.seed_arg} \\
             --n-jobs {threads} \\
             --output-dir {params.outdir}
 
@@ -1244,13 +1240,31 @@ rule download_obo:
   shell: "wget -O {output} 'http://purl.obolibrary.org/obo/go/go-basic.obo'"
 
 rule enrichment:
-  input:
-    expand("out/associations/{target}/COG.tsv", target=config["targets"]),
-    expand("out/associations/{target}/GO.tsv", target=config["targets"]),
-    expand("out/associations/{target}/KEGG.tsv", target=config["targets"]),
-    expand("out/wg/{target}/COG_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST),
-    expand("out/wg/{target}/GO_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST),
-    expand("out/wg/{target}/KEGG_{model}.tsv", target=config["targets"], model=WG_MODELS_LIST)
+    input:
+        expand('out/associations/{target}/COG.tsv',
+               target=config["targets"]),
+        expand('out/associations/{target}/GO.tsv',
+               target=config["targets"]),
+        expand('out/associations/{target}/KEGG.tsv',
+               target=config["targets"]),
+        expand('out/associations/{target}/COG_{kind}.tsv',
+               target=config["targets"],
+               kind=['gpa', 'rare', 'panfeed']),
+        expand('out/associations/{target}/GO_{kind}.tsv',
+               target=config["targets"],
+               kind=['gpa', 'rare', 'panfeed']),
+        expand('out/associations/{target}/KEGG_{kind}.tsv',
+               target=config["targets"],
+               kind=['gpa', 'rare', 'panfeed']),
+        expand("out/wg/{target}/COG_{model}.tsv",
+               target=config["targets"],
+               model=["ridge", "lasso", "bac_nortia"]),
+        expand("out/wg/{target}/GO_{model}.tsv",
+               target=config["targets"],
+               model=["ridge", "lasso", "bac_nortia"]),
+        expand("out/wg/{target}/KEGG_{model}.tsv",
+               target=config["targets"],
+               model=["ridge", "lasso", "bac_nortia"])
 
 rule run_enrich:
   input:
@@ -1305,12 +1319,39 @@ rule run_enrich_wg:
 
 rule enrichment_plots:
   input:
-    expand("out/associations/{target}/COG.{format}", target=config["targets"], format=['png', 'svg']),
-    expand("out/associations/{target}/GO.{format}", target=config["targets"], format=['png', 'svg']),
-    expand("out/associations/{target}/KEGG.{format}", target=config["targets"], format=['png', 'svg']),
-    expand("out/wg/{target}/COG_{model}.{format}", target=config["targets"], model=WG_MODELS_LIST, format=['png', 'svg']),
-    expand("out/wg/{target}/GO_{model}.{format}", target=config["targets"], model=WG_MODELS_LIST, format=['png', 'svg']),
-    expand("out/wg/{target}/KEGG_{model}.{format}", target=config["targets"], model=WG_MODELS_LIST, format=['png', 'svg'])
+    expand("out/associations/{target}/COG.{format}",
+           target=config["targets"],
+           format=['png', 'svg']),
+    expand("out/associations/{target}/GO.{format}",
+           target=config["targets"],
+           format=['png', 'svg']),
+    expand("out/associations/{target}/KEGG.{format}",
+           target=config["targets"],
+           format=['png', 'svg']),
+    expand('out/associations/{target}/COG_{kind}.{format}',
+           target=config["targets"],
+           kind=['gpa', 'rare', 'panfeed'],
+           format=['png', 'svg']),
+    expand('out/associations/{target}/GO_{kind}.{format}',
+           target=config["targets"],
+           kind=['gpa', 'rare', 'panfeed'],
+           format=['png', 'svg']),
+    expand('out/associations/{target}/KEGG_{kind}.{format}',
+           target=config["targets"],
+           kind=['gpa', 'rare', 'panfeed'],
+           format=['png', 'svg']),
+    expand("out/wg/{target}/COG_{model}.{format}",
+           target=config["targets"],
+           model=WG_MODELS_LIST,
+           format=['png', 'svg']),
+    expand("out/wg/{target}/GO_{model}.{format}",
+           target=config["targets"],
+           model=WG_MODELS_LIST,
+           format=['png', 'svg']),
+    expand("out/wg/{target}/KEGG_{model}.{format}",
+           target=config["targets"],
+           model=WG_MODELS_LIST,
+           format=['png', 'svg']),
 
 rule run_enrichment_plots:
   input:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -56,7 +56,7 @@ rule ggcaller:
     gfa=config["ggcaller_gfa"]
   params:
     outdir=config["ggcaller_dir"]
-  threads: 8
+  threads: 16
   conda: "envs/ggcaller.yaml"
   log: "out/logs/ggcaller.log"
   shell:

--- a/workflow/envs/bac_nortia.yaml
+++ b/workflow/envs/bac_nortia.yaml
@@ -2,10 +2,26 @@ name: bac_nortia
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - python>=3.9
+  - python>=3.10
   - pip
   - git
+  - numpy>=1.24
+  - scipy>=1.10
+  - pandas>=2.0
+  - scikit-learn>=1.3
+  - xgboost>=2.0
+  - catboost>=1.2
+  - lightgbm>=4.0
+  - pytorch>=2.0
+  - optuna>=3.4
+  - shap>=0.46
+  - numba>=0.59
+  - pysam>=0.22
+  - pyyaml>=6.0
+  - matplotlib>=3.7
+  - tqdm>=4.65
+  - pytorch-tabnet>=4.1
+  - tabpfn>=6.0.0
   - pip:
       - git+https://github.com/microbial-pangenomes-lab/bac-nortia.git

--- a/workflow/envs/bac_nortia.yaml
+++ b/workflow/envs/bac_nortia.yaml
@@ -1,0 +1,11 @@
+name: bac_nortia
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python>=3.9
+  - pip
+  - git
+  - pip:
+      - git+https://github.com/microbial-pangenomes-lab/bac-nortia.git

--- a/workflow/scripts/enrich_plots.py
+++ b/workflow/scripts/enrich_plots.py
@@ -36,9 +36,12 @@ def plot_enrichment(data, plot_file, category_label, count_col,
 
     cmap = plt.cm.viridis.copy()
     cmap.set_under('grey')
+    
+    real_max = enrichment_data_sorted['-log10(padj)'].max()
+    v_max = max(2.0, real_max)
+    
     cmap = plt.cm.ScalarMappable(cmap=cmap,
-                                 norm=plt.Normalize(vmin=-np.log10(0.01),
-                                                    vmax=-np.log10(1E-10)))
+                                 norm=plt.Normalize(vmin=0.0, vmax=v_max))
     cmap.set_array([])
 
     height = max([8, enrichment_data_sorted.shape[0] / 6])

--- a/workflow/scripts/enrich_plots.py
+++ b/workflow/scripts/enrich_plots.py
@@ -37,11 +37,9 @@ def plot_enrichment(data, plot_file, category_label, count_col,
     cmap = plt.cm.viridis.copy()
     cmap.set_under('grey')
     
-    real_max = enrichment_data_sorted['-log10(padj)'].max()
-    v_max = max(2.0, real_max)
-    
     cmap = plt.cm.ScalarMappable(cmap=cmap,
-                                 norm=plt.Normalize(vmin=0.0, vmax=v_max))
+                                 norm=plt.Normalize(vmin=-np.log10(0.01),
+                                                    vmax=-np.log10(1E-10)))
     cmap.set_array([])
 
     height = max([8, enrichment_data_sorted.shape[0] / 6])

--- a/workflow/scripts/shap_to_wg.py
+++ b/workflow/scripts/shap_to_wg.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--shap", required=True)
+parser.add_argument("--out", required=True)
+args = parser.parse_args()
+
+df = pd.read_csv(args.shap, sep="\t")
+out = pd.DataFrame()
+
+out['variant'] = df['feature']
+out['af'] = 0.5
+out['lrt-pvalue'] = 1.0
+out['filter-pvalue'] = 1.0
+
+if 'mean_abs_shap' in df.columns:
+    out['beta'] = df['mean_abs_shap']
+elif 'mean_shap_value' in df.columns:
+    out['beta'] = df['mean_shap_value']
+else:
+    out['beta'] = 1.0
+
+out.to_csv(args.out, sep="\t", index=False)

--- a/workflow/scripts/shap_to_wg.py
+++ b/workflow/scripts/shap_to_wg.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -10,9 +11,9 @@ df = pd.read_csv(args.shap, sep="\t")
 out = pd.DataFrame()
 
 out['variant'] = df['feature']
-out['af'] = 0.5
-out['lrt-pvalue'] = 1.0
-out['filter-pvalue'] = 1.0
+out['af'] = np.nan
+out['lrt-pvalue'] = np.nan
+out['filter-pvalue'] = np.nan
 
 if 'mean_abs_shap' in df.columns:
     out['beta'] = df['mean_abs_shap']


### PR DESCRIPTION
This update fixes compatibility issues to fully integrate Bac Nortia into the microGWAS pipeline. We modified the shap to wg conversion script by adding dummy columns for allele frequency and p values, which prevents downstream crashes during the summary generation step. Additionally, we updated the enrichment plotting script to use a dynamic color scale instead of hardcoded limits.