### PR TITLE
add pytz dependency to eggnog-mapper env

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -84,6 +84,7 @@ rule ggcaller:
         ggcaller --refs {input.fasta_list} --out {params.outdir} --threads {threads} >> {log} 2>&1
         echo "ggcaller finished; sample GFFs are in {params.outdir}/GFF/" >> {log}
     fi
+    touch {output}
     """
     
 rule download_eggnog:

--- a/workflow/envs/eggnog-mapper.yaml
+++ b/workflow/envs/eggnog-mapper.yaml
@@ -3,6 +3,7 @@ channels:
  - bioconda
 dependencies:
  - python=3.11
+ - pytz
  - pandas
  - diamond >= 2.0.11
  - eggnog-mapper >= 2.1.6


### PR DESCRIPTION
I was getting the following error:

```
cat out/logs/annotate_reference.log
Traceback (most recent call last):
  File "/rs_scratch/users/jb25u082/Sp_CSF/workflow/scripts/sample_pangenome.py", line 41, in <module>
    import pandas as pd
  File "/storage/homefs/jb25u082/.local/lib/python3.11/site-packages/pandas/__init__.py", line 19, in <module>
    raise ImportError(
ImportError: Unable to import required dependencies:
pytz: No module named 'pytz'
#  emapper-2.1.13-e13a7c1
# emapper.py  -i out/reference.faa -o out/reference --cpu 8 --target_orthologs one2one --go_evidence all --tax_scope Bacteria --pfam_realign none --override --data_dir data/eggnog-mapper
...
```

Adding the pytz dependency to the env solved it.